### PR TITLE
Update mistral.py

### DIFF
--- a/vllm/model_executor/models/mistral.py
+++ b/vllm/model_executor/models/mistral.py
@@ -279,7 +279,8 @@ class MistralForCausalLM(nn.Module):
         self.model = MistralModel(config,
                                   linear_method,
                                   lora_config=lora_config)
-        unpadded_vocab_size = config.vocab_size
+        orignal_unpadded_vocab_size = unpadded_vocab_size = min(config.vocab_size, len(self.tokenizer))
+      
         if lora_config:
             unpadded_vocab_size += lora_config.lora_extra_vocab_size
         self.lm_head = ParallelLMHead(
@@ -291,7 +292,7 @@ class MistralForCausalLM(nn.Module):
             # compatibility
             if not lora_config else lora_config.lora_vocab_padding_size,
         )
-        self.sampler = Sampler(unpadded_vocab_size, config.vocab_size)
+        self.sampler = Sampler(unpadded_vocab_size, orignal_unpadded_vocab_size)
 
     def forward(
         self,


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit b25c77955f7275d6dfae53d2f0c005342b497a83.  | 
|--------|--------|

### Summary:
This PR modifies the `MistralForCausalLM` class in `mistral.py` to ensure the vocabulary size does not exceed the length of the tokenizer by updating the calculation of `unpadded_vocab_size` and `original_unpadded_vocab_size`.

**Key points**:
- Updated `MistralForCausalLM` class in `mistral.py`.
- Changed calculation of `unpadded_vocab_size` and `original_unpadded_vocab_size`.
- `unpadded_vocab_size` is now the minimum of `config.vocab_size` and the length of `self.tokenizer`.
- Initialized `Sampler` class with these new values.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
